### PR TITLE
Gh deploy docs action

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,40 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Trigger the workflow every time you push to the `main` branch
+  # Using a different branch name? Replace `main` with your branch’s name
+  push:
+    branches: [ main ]
+  # Allows you to run this workflow manually from the Actions tab on GitHub.
+  workflow_dispatch:
+
+# Allow this job to clone the repo and create a page deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+      - name: Install, build, and upload your site
+        uses: withastro/action@v3
+        with:
+          path: docs # The root location of your Astro project inside the repository.
+          node-version: 20 # Use Node 20 for Astro 5
+        # env:
+          # PUBLIC_POKEAPI: 'https://pokeapi.co/api/v2' # Use single quotation marks for the variable value. (optional)
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,9 +13,7 @@
     "prebuild": "npm run build:typedoc-plugin",
     "build": "rm -rf dist && npm run build:typedoc-plugin && astro check && astro build",
     "preview": "astro preview",
-    "astro": "astro",
-    "predeploy": "npm run build",
-    "deploy": "npx gh-pages -d dist --branch gh-pages --dotfiles"
+    "astro": "astro"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "test": "bun test:types && vitest run --coverage",
     "test:types": "tsc --noEmit --skipLibCheck",
     "dry-run": "npm run build && npm test && npx changelogen --dry-run && npm publish --dry-run",
-    "publish:lib": "npm publish --access public",
-    "publish:docs": "npm --workspace docs run deploy || echo 'Add a deploy script to docs/package.json'"
+    "publish": "npm publish --access public"
+    
   },
   "devDependencies": {
     "@size-limit/preset-small-lib": "^10.0.1",


### PR DESCRIPTION
This pull request updates the documentation deployment workflow to use GitHub Actions for building and deploying the docs site to GitHub Pages, replacing the previous manual deployment via `gh-pages`. The changes streamline the deployment process and remove now-unnecessary deployment scripts from the project configuration.

**Documentation deployment workflow:**

* Added a new GitHub Actions workflow in `.github/workflows/deploy-docs.yml` to automate building and deploying the docs site using Astro and GitHub Pages.

**Configuration cleanup:**

* Removed the `predeploy` and `deploy` scripts from `docs/package.json` since deployment is now handled by GitHub Actions.
* Removed the `publish:docs` script from the root `package.json` as it is no longer needed with the new deployment workflow.
* Removed the `publish:lib` script from the root `package.json` and replaced it with a simplified `publish` script for publishing the library.