### PR TITLE
docs: server-render hero diagram + composable MachineDiagram

### DIFF
--- a/docs/src/code/examples/landing-fetcher/machine.ts
+++ b/docs/src/code/examples/landing-fetcher/machine.ts
@@ -1,25 +1,24 @@
 import { createMachine, defineStates, addEventApi } from "matchina";
 
+export const createLandingFetcherMachine = () => addEventApi(machine);
+export type LandingFetcherMachine = ReturnType<typeof createLandingFetcherMachine>;
+
+// ---cut-before---
 const states = defineStates({
-  Idle: undefined,
+  Idle:    undefined,
   Loading: undefined,
   Success: (data: unknown) => data,
-  Error: (err: Error) => err,
+  Error:   (err: Error)    => err,
 });
 
-export function createLandingFetcherMachine() {
-  return addEventApi(
-    createMachine(
-      states,
-      {
-        Idle:    { fetch:   "Loading" },
-        Loading: { resolve: "Success", reject: "Error" },
-        Success: { reset:   "Idle"    },
-        Error:   { retry:   "Loading" },
-      },
-      "Idle"
-    )
-  );
-}
-
-export type LandingFetcherMachine = ReturnType<typeof createLandingFetcherMachine>;
+const machine = createMachine(
+  states,
+  {
+    Idle:    { fetch:   'Loading' },
+    Loading: { resolve: 'Success', reject: 'Error' },
+    Success: { reset:   'Idle'    },
+    Error:   { retry:   'Loading' },
+  },
+  'Idle'
+);
+// ---cut-after---

--- a/docs/src/components/CodeBlock.astro
+++ b/docs/src/components/CodeBlock.astro
@@ -40,7 +40,14 @@ if (twoslash && ["ts", "tsx"].includes(lang)) {
 // }
 
 function applyCut(s: string) {
-  return s.split(/\/\/ \-\-\-cut\-\-\-\s*/).pop() ?? "";
+  // Twoslash directives: `---cut---` and `---cut-before---` hide everything above;
+  // `---cut-after---` hides everything below. Supports sandwich form.
+  let out = s;
+  const before = out.split(/\/\/ \-\-\-cut(?:-before)?\-\-\-\s*/);
+  if (before.length > 1) out = before.pop() ?? "";
+  const after = out.split(/\/\/ \-\-\-cut-after\-\-\-\s*/);
+  if (after.length > 1) out = after.shift() ?? "";
+  return out;
 }
 function mapPaths(s: string) {
   // return s.replace(/import \* as (\w+) from "(\w+)"/g, 'import $1 from "$2"')

--- a/docs/src/components/HeroCard.astro
+++ b/docs/src/components/HeroCard.astro
@@ -1,99 +1,56 @@
 ---
-import { ExamplePreview } from "./ExamplePreview";
+import CodeBlock from "./CodeBlock.astro";
+import { HeroFetcherDiagram } from "./HeroFetcherDiagram";
+import { getExample } from "../examples";
+
+const id = "landing-fetcher";
+const meta = getExample(id);
+const sourceFiles = meta ? await meta.getSourceFiles() : [];
+const machineSource = sourceFiles.find((f) => f.name === "machine.ts")?.code ?? "";
 ---
 
-<div class="hero-card not-content">
-  <div class="pane-left">
-    <div class="pane-head">
+<div class="not-content mt-5 grid grid-cols-1 border border-border bg-card lg:grid-cols-2">
+  <div class="flex flex-col border-b border-border p-5 lg:border-b-0 lg:border-r">
+    <div class="mb-3 flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.1em] text-text-mute">
       <span>fig.01 — fetcher machine</span>
-      <span class="live-badge">● live</span>
+      <span class="text-accent">● live</span>
     </div>
-    <ExamplePreview id="landing-fetcher" defaultViz="svg" showPicker={false} hideAppPane={true} defaultSvgDirection="DOWN" client:only="react" />
+    <div class="relative min-h-[320px] flex-1 sm:min-h-[360px] [&>astro-island]:absolute [&>astro-island]:inset-0 [&>astro-island]:block">
+      <HeroFetcherDiagram client:only="react" />
+    </div>
   </div>
-  <div class="pane-right">
-    <div class="pane-head">
+
+  <div class="flex min-w-0 flex-col">
+    <div class="flex items-center justify-between border-b border-border-soft px-5 pb-2.5 pt-4 font-mono text-[10px] uppercase tracking-[0.1em] text-text-mute">
       <span>fetcher.ts</span>
       <span>typescript</span>
     </div>
-    <pre class="hero-code"><code
-><span class="ln">01</span>  <span class="kw">const</span> states <span class="op">=</span> <span class="fn">defineStates</span>(&#123;
-<span class="ln">02</span>    Idle:    undefined,
-<span class="ln">03</span>    Loading: undefined,
-<span class="ln">04</span>    Success: (data: unknown) <span class="op">=&gt;</span> data,
-<span class="ln">05</span>    Error:   (err: Error)    <span class="op">=&gt;</span> err,
-<span class="ln">06</span>  &#125;);
-<span class="ln">07</span>
-<span class="ln">08</span>  <span class="kw">const</span> &#123; getState, send &#125; <span class="op">=</span> <span class="fn">createMachine</span>(
-<span class="ln">09</span>    states,
-<span class="ln">10</span>    &#123;
-<span class="ln">11</span>      Idle:    &#123; fetch:   <span class="s">'Loading'</span> &#125;,
-<span class="ln">12</span>      Loading: &#123; resolve: <span class="s">'Success'</span>, reject: <span class="s">'Error'</span> &#125;,
-<span class="ln">13</span>      Success: &#123; reset:   <span class="s">'Idle'</span>    &#125;,
-<span class="ln">14</span>      Error:   &#123; retry:   <span class="s">'Loading'</span> &#125;,
-<span class="ln">15</span>    &#125;,
-<span class="ln">16</span>    <span class="s">'Idle'</span>
-<span class="ln">17</span>  );
-<span class="ln">18</span>
-<span class="ln">19</span>  send(<span class="s">'fetch'</span>);</code></pre>
+    <div class="hero-code min-w-0 flex-1 overflow-auto">
+      <CodeBlock code={machineSource} lang="ts" />
+    </div>
   </div>
 </div>
 
-<style>
-  .hero-card {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    border: 1px solid var(--border);
-    background: var(--card);
-    margin-top: 20px;
+<style is:global>
+  /* Make Starlight's <Code> blend into the hero card frame. */
+  .hero-code .expressive-code,
+  .hero-code .expressive-code .frame,
+  .hero-code .expressive-code pre {
+    margin: 0;
+    border-radius: 0;
+    border: 0;
+    background: transparent;
   }
-  .pane-left {
-    border-right: 1px solid var(--border);
-    padding: 20px;
-    display: flex;
-    flex-direction: column;
+  .hero-code .expressive-code .frame {
+    box-shadow: none;
   }
-  .pane-right {
-    display: flex;
-    flex-direction: column;
+  .hero-code .expressive-code .frame.has-title .header,
+  .hero-code .expressive-code .copy {
+    display: none;
   }
-  .pane-head {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    font-family: var(--font-mono);
-    font-size: 10px;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    color: var(--text-mute);
-    margin-bottom: 14px;
-  }
-  .pane-right .pane-head {
-    padding: 16px 20px 10px;
-    border-bottom: 1px solid var(--border-soft);
-    margin-bottom: 0;
-  }
-  .hero-code {
-    margin: 0 !important;
-    padding: 14px 20px !important;
-    font-family: var(--font-mono) !important;
-    font-size: 12px !important;
-    line-height: 1.6 !important;
-    color: var(--muted-foreground) !important;
-    background: transparent !important;
-    border: 0 !important;
-    flex: 1;
-    overflow-x: auto;
-    overflow-y: auto;
-  }
-  .hero-code .ln { color: var(--text-mute); }
-  .hero-code .kw { color: var(--purple); }
-  .hero-code .fn { color: var(--info); }
-  .hero-code .s  { color: var(--warn); }
-  .hero-code .op { color: var(--text-mute); }
-  .live-badge { color: var(--accent); }
-
-  @media (max-width: 60rem) {
-    .hero-card { grid-template-columns: 1fr; }
-    .pane-left { border-right: 0; border-bottom: 1px solid var(--border); }
+  .hero-code .expressive-code pre {
+    padding: 14px 20px;
+    font-size: 12px;
+    line-height: 1.6;
   }
 </style>

--- a/docs/src/components/HeroCard.astro
+++ b/docs/src/components/HeroCard.astro
@@ -1,6 +1,8 @@
 ---
 import CodeBlock from "./CodeBlock.astro";
+import MachineDiagram from "./MachineDiagram.astro";
 import { HeroFetcherDiagram } from "./HeroFetcherDiagram";
+import { createLandingFetcherMachine } from "@code/examples/landing-fetcher/machine";
 import { getExample } from "../examples";
 
 const id = "landing-fetcher";
@@ -9,14 +11,17 @@ const sourceFiles = meta ? await meta.getSourceFiles() : [];
 const machineSource = sourceFiles.find((f) => f.name === "machine.ts")?.code ?? "";
 ---
 
-<div class="not-content mt-5 grid grid-cols-1 border border-border bg-card lg:grid-cols-2">
+<div id="hero-card" class="not-content mt-5 grid grid-cols-1 border border-border bg-card lg:grid-cols-2">
   <div class="flex flex-col border-b border-border p-5 lg:border-b-0 lg:border-r">
     <div class="mb-3 flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.1em] text-text-mute">
       <span>fig.01 — fetcher machine</span>
-      <span class="text-accent">● live</span>
+      <span class="opacity-0 transition-opacity text-accent [#hero-card[data-live]_&]:opacity-100">● live</span>
     </div>
     <div class="relative min-h-[320px] flex-1 sm:min-h-[360px] [&>astro-island]:absolute [&>astro-island]:inset-0 [&>astro-island]:block">
-      <HeroFetcherDiagram client:only="react" />
+      <div class="hero-ssr-svg absolute inset-0">
+        <MachineDiagram machine={createLandingFetcherMachine} options={{ direction: "DOWN" }} />
+      </div>
+      <HeroFetcherDiagram client:load />
     </div>
   </div>
 
@@ -32,6 +37,9 @@ const machineSource = sourceFiles.find((f) => f.name === "machine.ts")?.code ?? 
 </div>
 
 <style is:global>
+  /* Hide the build-time SSR diagram once the live React island has hydrated. */
+  #hero-card[data-live] .hero-ssr-svg { display: none; }
+
   /* Make Starlight's <Code> blend into the hero card frame. */
   .hero-code .expressive-code,
   .hero-code .expressive-code .frame,

--- a/docs/src/components/HeroFetcherDiagram.tsx
+++ b/docs/src/components/HeroFetcherDiagram.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useMachine } from "matchina/react";
 import { SvgInspector } from "@matchina/viz-svg";
 import { createLandingFetcherMachine } from "@code/examples/landing-fetcher/machine";
@@ -7,6 +7,9 @@ import { getActiveStatePath } from "@code/examples/lib/matchina-machine-to-xstat
 export function HeroFetcherDiagram() {
   const machine = useMemo(createLandingFetcherMachine, []);
   useMachine(machine);
+  useEffect(() => {
+    document.getElementById("hero-card")?.setAttribute("data-live", "");
+  }, []);
   const shape = (machine as any).shape?.getState();
   const value = getActiveStatePath(machine);
   return (

--- a/docs/src/components/HeroFetcherDiagram.tsx
+++ b/docs/src/components/HeroFetcherDiagram.tsx
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+import { useMachine } from "matchina/react";
+import { SvgInspector } from "@matchina/viz-svg";
+import { createLandingFetcherMachine } from "@code/examples/landing-fetcher/machine";
+import { getActiveStatePath } from "@code/examples/lib/matchina-machine-to-xstate-definition";
+
+export function HeroFetcherDiagram() {
+  const machine = useMemo(createLandingFetcherMachine, []);
+  useMachine(machine);
+  const shape = (machine as any).shape?.getState();
+  const value = getActiveStatePath(machine);
+  return (
+    <SvgInspector
+      shape={shape}
+      value={value}
+      onFire={(event) => (machine as any).send(event)}
+      options={{ direction: "DOWN" }}
+      interactive
+    />
+  );
+}

--- a/docs/src/components/MachineDiagram.astro
+++ b/docs/src/components/MachineDiagram.astro
@@ -1,0 +1,58 @@
+---
+/**
+ * Server-rendered machine diagram. Computes ELK layout at build time and
+ * inlines the resulting SVG into the HTML. No client JS required for the
+ * diagram itself; instant first paint.
+ *
+ * Usage:
+ *   <MachineDiagram machine={createFoo} options={{ direction: "DOWN" }}>
+ *     <Fragment slot="header">fig.01 — fetcher machine</Fragment>
+ *     <Fragment slot="footer"><LiveBadge /></Fragment>
+ *   </MachineDiagram>
+ *
+ * The default slot wraps the SVG; named slots layer above/below for chrome.
+ */
+import { runElkLayout, layoutToSvg, type ElkLayoutOptions } from "@matchina/viz-svg";
+
+interface Props {
+  /** Factory function that returns a matchina machine instance. */
+  machine: () => any;
+  /** ELK layout options. */
+  options?: ElkLayoutOptions;
+  /** Initial active state (dot-separated full key). Defaults to the machine's starting state. */
+  value?: string;
+  /** Extra class for the outer wrapper. */
+  class?: string;
+}
+
+const { machine: createMachine, options, value, class: className = "" } = Astro.props;
+
+// Build time: instantiate, get shape, run ELK, render SVG to string.
+const m = createMachine();
+const shape = (m as any).shape?.getState();
+const layout = await runElkLayout(shape, options ?? {});
+
+// Derive initial active state if caller didn't provide.
+let activeValue = value;
+if (!activeValue) {
+  const state = m.getState ? m.getState() : null;
+  const key = state?.key ?? state?.type;
+  if (key) activeValue = String(key);
+}
+
+const svg = layoutToSvg(layout, { value: activeValue });
+---
+
+<div class={`machine-diagram relative h-full w-full ${className}`}>
+  <slot name="header" />
+  <div class="machine-diagram-svg absolute inset-0" set:html={svg} />
+  <slot name="footer" />
+  <slot />
+</div>
+
+<style>
+  .machine-diagram-svg :global(svg) {
+    width: 100%;
+    height: 100%;
+  }
+</style>

--- a/packages/viz-svg/src/index.ts
+++ b/packages/viz-svg/src/index.ts
@@ -1,3 +1,6 @@
 export { SvgInspector } from './SvgInspector.js';
 export type { SvgInspectorProps } from './SvgInspector.js';
+export { runElkLayout } from './elk-layout.js';
 export type { ElkLayoutOptions, SvgLayout, SvgNode, SvgEdge } from './elk-layout.js';
+export { layoutToSvg } from './layout-to-svg.js';
+export type { LayoutToSvgOptions } from './layout-to-svg.js';

--- a/packages/viz-svg/src/layout-to-svg.ts
+++ b/packages/viz-svg/src/layout-to-svg.ts
@@ -1,0 +1,202 @@
+// Pure SVG string generator from an ELK layout.
+// Mirrors the rendering logic of SvgInspector.tsx, but emits a string instead of React elements.
+// Use this for build-time SSR (e.g. from Astro frontmatter) where no React runtime is needed.
+
+import type { SvgLayout, SvgNode, SvgEdge } from './elk-layout.js';
+import { buildCurvedPath, pathAtT } from './svg-path.js';
+
+// CSS variable names with their default values (dark teal theme).
+// Match SvgInspector.tsx.
+const V = {
+  accent: 'var(--matchina-viz-accent, #2dd4bf)',
+  bg: 'var(--matchina-viz-bg, #0a0f17)',
+  node: 'var(--matchina-viz-node, rgba(28,38,54,0.95))',
+  nodeActive: 'var(--matchina-viz-node-active, rgba(20,90,82,0.85))',
+  nodeCompound: 'var(--matchina-viz-node-compound, rgba(20,28,40,0.7))',
+  border: 'var(--matchina-viz-border, rgba(148,163,184,0.25))',
+  text: 'var(--matchina-viz-text, rgba(226,232,240,0.92))',
+  textActive: 'var(--matchina-viz-text-active, #e6fffb)',
+  edge: 'var(--matchina-viz-edge, rgba(100,116,139,0.55))',
+  labelBg: 'var(--matchina-viz-label-bg, rgba(15,23,33,0.95))',
+  labelBgActive: 'var(--matchina-viz-label-bg-active, rgba(8,47,51,0.95))',
+  labelText: 'var(--matchina-viz-label-text, rgba(203,213,225,0.82))',
+} as const;
+
+const FONT = "var(--matchina-viz-font, 'JetBrains Mono', monospace)";
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function nodeSvg(node: SvgNode, isActive: boolean, isAncestor: boolean): string {
+  const stroke = isActive || isAncestor ? V.accent : V.border;
+  const strokeWidth = isActive ? 2 : isAncestor ? 1.5 : 1;
+  const fill = node.isCompound ? V.nodeCompound : isActive ? V.nodeActive : V.node;
+  const textFill = isActive ? V.textActive : isActive || isAncestor ? V.accent : V.text;
+
+  const rect = `<rect x="${node.x}" y="${node.y}" width="${node.width}" height="${node.height}" rx="10" ry="10" style="fill:${fill};stroke:${stroke};stroke-width:${strokeWidth}" />`;
+
+  const label = node.isCompound
+    ? `<text x="${node.x + 14}" y="${node.y + 22}" style="fill:${isActive || isAncestor ? V.accent : V.text};font-family:${FONT};font-size:12px;font-weight:600;letter-spacing:0.06em">${esc(node.label)}</text>`
+    : `<text x="${node.x + node.width / 2}" y="${node.y + node.height / 2 + 5}" text-anchor="middle" style="fill:${textFill};font-family:${FONT};font-size:14px;font-weight:${isActive ? 600 : 500}">${esc(node.label)}</text>`;
+
+  const activeDot = isActive && !node.isCompound
+    ? `<circle cx="${node.x + node.width - 10}" cy="${node.y + 10}" r="4" style="fill:${V.accent}"><animate attributeName="opacity" values="1;0.35;1" dur="1.6s" repeatCount="indefinite" /></circle>`
+    : '';
+
+  return `<g data-node-id="${esc(node.id)}" data-active="${isActive}" data-ancestor="${isAncestor}">${rect}${label}${activeDot}</g>`;
+}
+
+function selfLoopSvg(edge: SvgEdge, node: SvgNode, isOutgoing: boolean, loopIndex: number): string {
+  const stroke = isOutgoing ? V.accent : V.edge;
+  const strokeWidth = isOutgoing ? 2 : 1.25;
+  const opacity = isOutgoing ? 1 : 0.65;
+  const markerId = isOutgoing ? 'matchina-svg-arrow-active' : 'matchina-svg-arrow';
+  const { label } = edge;
+
+  const hw = node.width / 2;
+  const hh = node.height / 2;
+  const sx = node.x + hw;
+  const sy = node.y + hh;
+  const loopRadius = 28 + loopIndex * 16;
+
+  const startX = sx + hw - 8 - loopIndex * 2;
+  const startY = sy - hh;
+  const endX = sx + hw;
+  const endY = sy - hh + 8 + loopIndex * 2;
+
+  const d = `M ${startX} ${startY} C ${startX} ${startY - loopRadius}, ${endX + loopRadius} ${endY}, ${endX} ${endY}`;
+  const labelX = sx + hw + loopRadius + 4;
+  const labelY = sy - hh - 10 + loopIndex * (label ? label.height + 8 : 24);
+
+  const path = `<path d="${d}" fill="none" style="stroke:${stroke};stroke-width:${strokeWidth};opacity:${opacity}" marker-end="url(#${markerId})" />`;
+
+  const labelMarkup = label
+    ? `<g transform="translate(${labelX}, ${labelY - label.height / 2})" style="opacity:${opacity}">
+        <rect x="-6" y="-2" width="${label.width + 12}" height="${label.height + 4}" rx="6" ry="6" style="fill:${isOutgoing ? V.labelBgActive : V.labelBg};stroke:${isOutgoing ? V.accent : 'rgba(100,116,139,0.45)'};stroke-width:${isOutgoing ? 1 : 0.75}" />
+        <text x="${label.width / 2}" y="${(label.height + 4) / 2 + 4}" text-anchor="middle" style="fill:${isOutgoing ? V.accent : V.labelText};font-family:${FONT};font-size:11px;font-weight:${isOutgoing ? 600 : 500};letter-spacing:0.04em">${esc(label.text)}</text>
+      </g>`
+    : '';
+
+  return `<g data-edge-id="${esc(edge.id)}" data-event="${esc(edge.event)}">${path}${labelMarkup}</g>`;
+}
+
+function edgeSvg(edge: SvgEdge, isOutgoing: boolean, labelT: number): string {
+  const section = edge.sections?.[0];
+  if (!section?.startPoint || !section?.endPoint) return '';
+
+  const d = buildCurvedPath(section);
+  const stroke = isOutgoing ? V.accent : V.edge;
+  const strokeWidth = isOutgoing ? 2 : 1.25;
+  const opacity = isOutgoing ? 1 : 0.65;
+  const { label } = edge;
+  const markerId = isOutgoing ? 'matchina-svg-arrow-active' : 'matchina-svg-arrow';
+  const mid = label ? pathAtT(section, labelT) : null;
+
+  const path = `<path d="${d}" fill="none" style="stroke:${stroke};stroke-width:${strokeWidth};opacity:${opacity}" marker-end="url(#${markerId})" />`;
+
+  const labelMarkup = label && mid
+    ? `<g transform="translate(${mid.x - label.width / 2}, ${mid.y - label.height / 2})" style="opacity:${opacity}">
+        <rect x="-6" y="-2" width="${label.width + 12}" height="${label.height + 4}" rx="6" ry="6" style="fill:${isOutgoing ? V.labelBgActive : V.labelBg};stroke:${isOutgoing ? V.accent : 'rgba(100,116,139,0.45)'};stroke-width:${isOutgoing ? 1 : 0.75}" />
+        <text x="${label.width / 2}" y="${(label.height + 4) / 2 + 4}" text-anchor="middle" style="fill:${isOutgoing ? V.accent : V.labelText};font-family:${FONT};font-size:11px;font-weight:${isOutgoing ? 600 : 500};letter-spacing:0.04em">${esc(label.text)}</text>
+      </g>`
+    : '';
+
+  return `<g data-edge-id="${esc(edge.id)}" data-event="${esc(edge.event)}">${path}${labelMarkup}</g>`;
+}
+
+export interface LayoutToSvgOptions {
+  /** Current active state value (dot-separated full key). */
+  value?: string;
+  /** Padding in px to inset content from the viewBox. Default 32. */
+  padding?: number;
+}
+
+/**
+ * Produce a complete SVG markup string from a precomputed ELK layout.
+ * Output is sized to the layout's intrinsic dimensions plus padding,
+ * with a viewBox so it scales to its container via `width="100%" height="100%"`.
+ */
+export function layoutToSvg(layout: SvgLayout, opts: LayoutToSvgOptions = {}): string {
+  const { value = '', padding = 32 } = opts;
+
+  const activePath = value ? value.split('.') : [];
+  const activeLeafId = value;
+
+  const activeAncestorIds = new Set<string>();
+  for (let i = 0; i < activePath.length - 1; i++) {
+    activeAncestorIds.add(activePath.slice(0, i + 1).join('.'));
+  }
+
+  const activeSourceIds = new Set<string>();
+  for (let i = 1; i <= activePath.length; i++) {
+    activeSourceIds.add(activePath.slice(0, i).join('.'));
+  }
+
+  // Spread label positions for parallel edges, same heuristic as SvgInspector.
+  const pairTotal = new Map<string, number>();
+  for (const edge of layout.edges) {
+    const key = `${edge.sourcePath.join('.')}→${edge.targetPath.join('.')}`;
+    pairTotal.set(key, (pairTotal.get(key) ?? 0) + 1);
+  }
+  const pairNextIdx = new Map<string, number>();
+  const edgeLabelT = new Map<string, number>();
+  for (const edge of layout.edges) {
+    const key = `${edge.sourcePath.join('.')}→${edge.targetPath.join('.')}`;
+    const count = pairTotal.get(key) ?? 1;
+    const idx = pairNextIdx.get(key) ?? 0;
+    pairNextIdx.set(key, idx + 1);
+    const t = count === 1 ? 0.5 : 0.3 + (idx / (count - 1)) * 0.4;
+    edgeLabelT.set(edge.id, t);
+  }
+
+  const compounds = layout.nodes.filter((n) => n.isCompound);
+  const leaves = layout.nodes.filter((n) => !n.isCompound);
+
+  const nodeById = new Map(layout.nodes.map((n) => [n.id, n]));
+  const selfLoopIndexByNode = new Map<string, number>();
+
+  const edgeMarkup = layout.edges.map((edge) => {
+    const isSelf = edge.sourcePath.join('.') === edge.targetPath.join('.');
+    const isOutgoing = activeSourceIds.has(edge.sourcePath.join('.'));
+    if (isSelf) {
+      const nodeId = edge.sourcePath.join('.');
+      const node = nodeById.get(nodeId);
+      if (!node) return '';
+      const loopIndex = selfLoopIndexByNode.get(nodeId) ?? 0;
+      selfLoopIndexByNode.set(nodeId, loopIndex + 1);
+      return selfLoopSvg(edge, node, isOutgoing, loopIndex);
+    }
+    return edgeSvg(edge, isOutgoing, edgeLabelT.get(edge.id) ?? 0.5);
+  }).join('');
+
+  const compoundsMarkup = compounds
+    .map((n) => nodeSvg(n, n.id === activeLeafId, activeAncestorIds.has(n.id)))
+    .join('');
+  const leavesMarkup = leaves
+    .map((n) => nodeSvg(n, n.id === activeLeafId, activeAncestorIds.has(n.id)))
+    .join('');
+
+  const vw = layout.width + padding * 2;
+  const vh = layout.height + padding * 2;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 ${vw} ${vh}" preserveAspectRatio="xMidYMid meet" style="display:block;background:${V.bg}">
+    <defs>
+      <marker id="matchina-svg-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" style="fill:rgba(100,116,139,0.7)" />
+      </marker>
+      <marker id="matchina-svg-arrow-active" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+        <path d="M 0 0 L 10 5 L 0 10 z" style="fill:${V.accent}" />
+      </marker>
+    </defs>
+    <g transform="translate(${padding}, ${padding})">
+      ${compoundsMarkup}
+      ${edgeMarkup}
+      ${leavesMarkup}
+    </g>
+  </svg>`;
+}


### PR DESCRIPTION
## Summary

Rebuilds the home page hero so the fetcher diagram ships in the initial HTML response — first paint shows the live diagram with zero client JS required. Adds a reusable `<MachineDiagram>` Astro component that any article can use to inline a server-rendered state machine diagram.

Two commits:

1. **Hero rebuild** — replaces the bespoke `<pre>` + `ExamplePreview` wrapper with a direct `SvgInspector` island composed via `HeroCard.astro` + `CodeBlock`. Extends `applyCut` in `CodeBlock` to support `---cut-before---` / `---cut-after---` (already used by `teaser/*` examples; previously only twoslash honored them). Restructures `landing-fetcher/machine.ts` with sandwich-cut so the rendered snippet is just the two declarations (`defineStates` + `createMachine`), no imports/factory boilerplate.

2. **Static prerender** — extracts `layoutToSvg(layout, opts) → string` as a pure SVG string generator from `SvgInspector`. New `MachineDiagram.astro` runs ELK in frontmatter (Node-side, build-time), inlines the SVG. `HeroCard` layers SSR diagram + React island for interactivity; CSS handoff via `[data-live]` hides the SSR copy once the island hydrates.

## What this unblocks

- Home page hero is server-rendered. No "took forever to come up" gap.
- Same `<MachineDiagram machine={createFoo}>` pattern works in any `.mdx` article. ELK runs at build, SVG ships inline.
- Existing React `SvgInspector` is unchanged — still used by `MachineVisualizer`/`ExamplePreview` for the interactive playground.

## Test plan
- [ ] Verify hero diagram renders in initial HTML (view source on Netlify preview)
- [ ] Verify "● live" indicator stays hidden until React island hydrates
- [ ] Click diagram nodes/edges → fires events as expected
- [ ] Sandwich-cut still works in teaser pages
- [ ] No regressions on `/examples/*` pages (still use React `SvgInspector` via `MachineVisualizer`)