### PR TITLE
fix(docs): mobile nav, example viewer stacking, sidebar link, panel padding

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -115,7 +115,7 @@ export default defineConfig({
                 {
                   label: "Stopwatches",
                   items: [
-                    { label: "Overview", link: "/examples/stopwatch-overview" },
+                    { label: "Overview", link: "/learn/examples/stopwatch-overview" },
                     { label: "Basic Stopwatch", link: "/examples/stopwatch" },
                     { label: "With Hooks", link: "/examples/stopwatch-using-data-and-hooks" },
                     { label: "With Transition Functions", link: "/examples/stopwatch-using-data-and-transition-functions" },

--- a/docs/src/components/MachineVisualizer.tsx
+++ b/docs/src/components/MachineVisualizer.tsx
@@ -107,7 +107,7 @@ export function MachineVisualizer({
   const isVizLeft = vizPosition === "left";
 
   const containerClasses = [
-    isSplit ? "flex flex-row gap-4 flex-1 min-h-0" : "flex flex-col gap-4",
+    isSplit ? "flex flex-col sm:flex-row gap-4 flex-1 min-h-0" : "flex flex-col gap-4",
     isSplit && !isVizLeft ? "flex-row-reverse" : "",
   ]
     .filter(Boolean)
@@ -254,7 +254,7 @@ function renderVisualizer({
   switch (type) {
     case "reactflow":
       return (
-        <div className={commonClasses}>
+        <div className="w-full h-full border border-border overflow-hidden">
           <ReactFlowProvider>
             <HSMReactFlowInspector
               machine={machine as any}

--- a/docs/src/components/starlight/PageFrame.astro
+++ b/docs/src/components/starlight/PageFrame.astro
@@ -72,7 +72,7 @@ const { hasSidebar } = Astro.locals.starlightRoute;
             inset-block: var(--sl-nav-height) 0;
             inset-inline-start: 0;
             width: 100%;
-            background-color: var(--sl-color-black);
+            background-color: var(--sl-color-bg-sidebar);
             overflow-y: auto;
         }
 

--- a/docs/src/pages/examples/[id].astro
+++ b/docs/src/pages/examples/[id].astro
@@ -234,6 +234,12 @@ function getLang(filename: string): string {
     padding: 1.5rem;
   }
   .ex-panel.is-hidden { display: none; }
+  @media (max-width: 639px) {
+    .ex-panel--preview,
+    .ex-panel--code {
+      padding: 0.75rem;
+    }
+  }
 
   /* ── skeleton ── */
   .ex-skeleton {

--- a/docs/src/styles/starlight-overrides.css
+++ b/docs/src/styles/starlight-overrides.css
@@ -169,8 +169,16 @@ select[aria-label="Select theme"] {
 /* ---------- Main content ---------- */
 
 .main-frame { padding-top: 0; }
+.main-pane { min-height: calc(100dvh - var(--sl-nav-height)); display: flex; flex-direction: column; }
+.main-pane > .content-panel:first-child { flex: 1; }
 .content-panel { padding: 48px 56px; border: 0; }
 .content-panel + .content-panel { border-top: 1px solid var(--sl-color-hairline); }
+
+@media (max-width: 50rem) {
+  .content-panel { padding: 24px 12px; }
+  .pagination-links a { padding: 10px 12px; }
+  .pagination-links a .link-title { font-size: var(--sl-text-base); display: -webkit-box; -webkit-line-clamp: 1; -webkit-box-orient: vertical; overflow: hidden; }
+}
 
 /* Breadcrumbs / rail labels — reusable .eyebrow utility */
 .eyebrow {

--- a/docs/src/styles/starlight-overrides.css
+++ b/docs/src/styles/starlight-overrides.css
@@ -169,8 +169,6 @@ select[aria-label="Select theme"] {
 /* ---------- Main content ---------- */
 
 .main-frame { padding-top: 0; }
-.main-pane { min-height: calc(100dvh - var(--sl-nav-height)); display: flex; flex-direction: column; }
-.main-pane > .content-panel:first-child { flex: 1; }
 .content-panel { padding: 48px 56px; border: 0; }
 .content-panel + .content-panel { border-top: 1px solid var(--sl-color-hairline); }
 
@@ -329,6 +327,11 @@ a.action.secondary {
   border: 1px solid var(--sl-color-hairline);
   padding: 0.5px 5px;
 }
+
+/* TwoSlash hover popups: EC renders all popups in static HTML; JS hides them.
+ * Without JS (or pre-hydration) they all render at once and overlap the code. */
+.twoslash-popup-container { display: none; }
+.twoslash:hover .twoslash-popup-container { display: block; }
 
 /* ---------- .not-content = scoped Tailwind preflight for embeds ----------
  * apps/docs skips global Tailwind preflight (see global.css) because it

--- a/docs/src/styles/themes/editorial.css
+++ b/docs/src/styles/themes/editorial.css
@@ -58,7 +58,8 @@
   --highlight-inset: none;
 }
 
-[data-theme="editorial-dark"] {
+[data-theme="editorial-dark"],
+[data-theme="dark"] {
   --font-sans: "Geist", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
   --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", serif;
   --font-display: "Source Serif 4", "Iowan Old Style", Georgia, serif;


### PR DESCRIPTION
## Summary

Post-release dogfood fixes for the docs site (tested at 390×844 mobile and 1440px desktop).

- **Mobile nav black screen** — `.sidebar-pane` was using `--sl-color-black` (resolves to `--background`, near-black) for the mobile drawer background; switched to `--sl-color-bg-sidebar` so nav links are visible
- **Example viewer h-split on mobile** — changed `flex flex-row` → `flex flex-col sm:flex-row` so the diagram/preview split stacks vertically on narrow screens instead of forcing a broken horizontal split
- **ReactFlow controls overflow** — changed wrapper from `overflow-auto` to `overflow-hidden` so absolutely-positioned ReactFlow panels stay clipped inside the viz container
- **Mobile panel padding** — added `@media (max-width: 639px)` reducing `.ex-panel` padding from `1.5rem` to `0.75rem`
- **Stopwatch Overview sidebar link 404** — fixed sidebar config link from `/examples/stopwatch-overview` to `/learn/examples/stopwatch-overview`

## Test plan

- [ ] Open mobile nav (hamburger) at 390px — should show all sections with readable text
- [ ] Visit `/matchina/learn/examples/toggle/` at 390px — viewer should stack diagram above interactive preview
- [ ] Click STOPWATCHES > Overview in sidebar — should load page, not 404
- [ ] Check example panel padding is tighter on mobile