### PR TITLE
docs: fill documentation gaps (viz-svg, createStore, subscriptions)

### DIFF
--- a/docs/src/content/docs/guides/store-machine.mdx
+++ b/docs/src/content/docs/guides/store-machine.mdx
@@ -168,8 +168,42 @@ function Counter({ store }) {
 | Pattern matching | N/A | `state.match({...})` |
 | Use case | App state, forms, counters | Workflows, async flows, UI modes |
 
+## `createStore` — batteries-included shorthand
+
+`createStore` is a convenience wrapper around `createStoreMachine` that adds two things:
+
+- **Direct action methods** on the store object (`store.increment(1)` instead of `store.dispatch("increment", 1)`)
+- **`subscribe(fn)`** — a standard subscribe/unsubscribe pattern via `withSubscribe`
+
+```ts
+import { createStore } from 'matchina';
+
+const counter = createStore(0, {
+  increment: (n = 1) => (ch) => ch.from + n,
+  reset: () => 0,
+});
+
+counter.subscribe(ev => console.log(ev.from, "→", ev.to));
+
+counter.increment();      // direct method, no dispatch
+counter.increment(5);
+counter.reset();
+```
+
+### When to use each
+
+| | `createStore` | `createStoreMachine` |
+|---|---|---|
+| Direct action methods | ✓ | ✗ |
+| Built-in `subscribe(fn)` | ✓ | ✗ |
+| `dispatch(action, ...params)` | ✓ | ✓ |
+| Bare primitive for manual composition | ✗ | ✓ |
+
+Use `createStore` for app code, CDN artifacts, demos, and one-liner setups where you want the convenience API out of the box. Use `createStoreMachine` directly when you want the primitive and will compose `subscribe`, action methods, or other wrappers yourself.
+
 ## Next Steps
 
 - [Lifecycle & Hooks](/matchina/guides/lifecycle/) - Add side effects to your store
 - [Effects](/matchina/guides/effects/) - Declarative effect management
+- [Subscriptions](/matchina/guides/subscriptions/) - Observe state changes across machines
 - [Factory Machines](/matchina/guides/machines/) - For discrete state management

--- a/docs/src/content/docs/guides/subscriptions.mdx
+++ b/docs/src/content/docs/guides/subscriptions.mdx
@@ -1,22 +1,141 @@
 ---
 title: Subscriptions
-description: Observe state changes in your state machines
+description: Observe state changes in your state machines without affecting them
 ---
 
-## Advanced Pattern: State Change Subscriptions
+Subscriptions let you react to state changes passively — observing without triggering transitions. Every Matchina machine type supports `subscribe`.
 
-For observing state changes without affecting them, you can use `subscribe`:
+## What is a subscription?
+
+`subscribe(fn)` registers a callback that fires after every state change. It returns an unsubscribe function you call when the observer is no longer needed.
 
 ```ts
-// Subscribe to all state changes
-const unsubscribe = counter.subscribe((state) => {
-  console.log(`State changed to: ${state.key}`);
+const unsubscribe = machine.subscribe((state) => {
+  console.log('State changed:', state);
+});
 
-  if (state.is("Counting")) {
-    console.log(`Current count: ${state.data.count}`);
+// Later:
+unsubscribe();
+```
+
+The callback receives the new state (for factory machines) or the change event (for store machines).
+
+## Factory machine subscriptions
+
+For factory machines, the callback receives the new state object with `.key`, `.data`, and `.is()`.
+
+```ts
+import { createMachine } from 'matchina';
+
+const traffic = createMachine({
+  Red: { go: 'Green' },
+  Green: { stop: 'Red', slow: 'Yellow' },
+  Yellow: { stop: 'Red' },
+});
+
+const unsubscribe = traffic.subscribe((state) => {
+  console.log(`Light changed to: ${state.key}`);
+
+  if (state.is('Green')) {
+    console.log('Go!');
   }
 });
 
-// Later, when no longer needed:
+traffic.send('go');   // logs: "Light changed to: Green", "Go!"
+traffic.send('slow'); // logs: "Light changed to: Yellow"
+
 unsubscribe();
 ```
+
+## Store machine subscriptions
+
+For store machines created with `createStore`, `subscribe` is built in. The callback receives a change event with `from`, `to`, `type`, and `params`.
+
+```ts
+import { createStore } from 'matchina';
+
+const counter = createStore(0, {
+  increment: (n = 1) => (ch) => ch.from + n,
+  reset: () => 0,
+});
+
+const unsubscribe = counter.subscribe((ev) => {
+  console.log(`${ev.type}: ${ev.from} → ${ev.to}`);
+});
+
+counter.increment();    // logs: "increment: 0 → 1"
+counter.increment(4);   // logs: "increment: 1 → 5"
+counter.reset();        // logs: "reset: 5 → 0"
+
+unsubscribe();
+```
+
+If you used `createStoreMachine` directly (the bare primitive), add `subscribe` via `withSubscribe`:
+
+```ts
+import { createStoreMachine, withSubscribe } from 'matchina';
+
+const machine = withSubscribe(createStoreMachine(0, { increment: () => (ch) => ch.from + 1 }));
+const unsub = machine.subscribe(ev => console.log(ev));
+```
+
+## Multiple subscribers
+
+You can register as many subscribers as you need. Each gets its own unsubscribe handle.
+
+```ts
+const unsubA = store.subscribe(ev => syncToLocalStorage(ev.to));
+const unsubB = store.subscribe(ev => updateAnalytics(ev.type));
+
+// Remove just one:
+unsubA();
+```
+
+## Subscribe vs lifecycle hooks
+
+Both `subscribe` and [lifecycle hooks](/matchina/guides/lifecycle/) let you react to state changes. The difference is scope and intent:
+
+| | `subscribe` | Lifecycle hooks (`effect`, `when`) |
+|---|---|---|
+| Fires after every change | ✓ | ✓ |
+| Can filter by event type | Manual (`if ev.type === ...`) | `when(predicate, fn)` |
+| Composable / declarative | ✗ | ✓ |
+| Returns unsubscribe fn | ✓ | Managed by `setup` |
+| External integrations | ✓ | ✓ |
+
+Use `subscribe` for straightforward integrations: syncing to external stores (React `useSyncExternalStore`), logging, or analytics. Use lifecycle hooks when you want a declarative, composable description of side effects that lives alongside the machine definition.
+
+## React integration
+
+`subscribe` maps directly to React's `useSyncExternalStore`:
+
+```tsx
+import { useSyncExternalStore } from 'react';
+import { createStore } from 'matchina';
+
+const counter = createStore(0, {
+  increment: () => (ch) => ch.from + 1,
+  decrement: () => (ch) => ch.from - 1,
+});
+
+function Counter() {
+  const count = useSyncExternalStore(
+    (callback) => counter.subscribe(() => callback()),
+    () => counter.getState(),
+  );
+
+  return (
+    <div>
+      <span>{count}</span>
+      <button onClick={() => counter.increment()}>+</button>
+      <button onClick={() => counter.decrement()}>−</button>
+    </div>
+  );
+}
+```
+
+## Next Steps
+
+- [Lifecycle & Hooks](/matchina/guides/lifecycle/) - Declarative side-effect management
+- [Effects](/matchina/guides/effects/) - Composable effect helpers
+- [Store Machine](/matchina/guides/store-machine/) - Full store machine reference

--- a/docs/src/content/docs/guides/viz-svg.mdx
+++ b/docs/src/content/docs/guides/viz-svg.mdx
@@ -1,0 +1,77 @@
+---
+title: Viz SVG
+description: SVG state machine visualizer for Matchina, powered by ELK auto-layout
+---
+
+`@matchina/viz-svg` renders an interactive SVG diagram of any Matchina state machine. Nodes are auto-laid out by ELK; clicking outgoing edges fires events directly.
+
+## Install
+
+```sh
+npm install @matchina/viz-svg
+# peer deps: matchina, react, react-dom
+```
+
+## Usage
+
+```tsx
+import { SvgInspector } from '@matchina/viz-svg';
+
+<SvgInspector
+  shape={machine.shape}
+  value={state.value}
+  onFire={(event) => machine.send(event)}
+/>
+```
+
+Give the container a fixed size — the component fills `100% × 100%`. Pan and zoom with the mouse wheel and drag; click outgoing edges to fire events.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `shape` | `MachineShape` | required | Machine shape from `matchina` |
+| `value` | `string` | required | Current state value |
+| `onFire` | `(event: string) => void` | — | Called when an outgoing edge is clicked |
+| `options` | `ElkLayoutOptions` | — | Layout options (direction, spacing, edge routing) |
+| `interactive` | `boolean` | `true` | Enable edge click events |
+| `precomputedLayout` | `SvgLayout` | — | Skip initial ELK run (useful for SSR) |
+
+### `ElkLayoutOptions`
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `direction` | `'DOWN'` | `'RIGHT'` or `'DOWN'` |
+| `edgeRouting` | `'ORTHOGONAL'` | `'ORTHOGONAL'` or `'POLYLINE'` |
+| `nodeSpacing` | `40` | Spacing between sibling nodes |
+| `layerSpacing` | `nodeSpacing + 20` | Spacing between layers |
+
+## Theming
+
+Override CSS variables on any ancestor element:
+
+| Variable | Default |
+|----------|---------|
+| `--matchina-viz-accent` | `#2dd4bf` |
+| `--matchina-viz-bg` | `#0a0f17` |
+| `--matchina-viz-node` | `rgba(28,38,54,0.95)` |
+| `--matchina-viz-node-active` | `rgba(20,90,82,0.85)` |
+| `--matchina-viz-border` | `rgba(148,163,184,0.25)` |
+| `--matchina-viz-text` | `rgba(226,232,240,0.92)` |
+| `--matchina-viz-edge` | `rgba(100,116,139,0.55)` |
+| `--matchina-viz-font` | `'JetBrains Mono', monospace` |
+
+## SSR / Pre-computed layouts
+
+```ts
+import { runElkLayout } from '@matchina/viz-svg';
+
+// At build time (Node.js / Astro frontmatter):
+const layout = await runElkLayout(machine.shape, { direction: 'RIGHT' });
+```
+
+Pass `precomputedLayout` to `<SvgInspector>` to render synchronously on first paint — no "computing layout…" placeholder.
+
+## Low-level exports
+
+`runElkLayout(shape, options)` → `Promise<SvgLayout>` — run ELK and get flat absolute-positioned node/edge arrays directly.


### PR DESCRIPTION
## Summary

Addresses the three high-priority gaps from the documentation audit (WIN-22):

- **Gap 1** — Create `guides/viz-svg.mdx`: full guide for the `@matchina/viz-svg` npm package (install, `<SvgInspector>` usage, props table, theming CSS vars, SSR via `runElkLayout`)
- **Gap 2** — Expand `guides/store-machine.mdx`: add `createStore` section with example, when-to-use table comparing `createStore` vs `createStoreMachine`, and link to Subscriptions guide
- **Gap 3** — Rewrite `guides/subscriptions.mdx`: was a 22-line stub; now covers factory machine + store machine examples, multiple subscribers, subscribe vs lifecycle hooks comparison, and React `useSyncExternalStore` integration

## Test plan

- [ ] `pnpm build` in `docs/` compiles without errors
- [ ] `/guides/viz-svg` renders with correct content, props table, and theming section
- [ ] `/guides/store-machine` shows the new `createStore` section with working code examples
- [ ] `/guides/subscriptions` renders fully with all examples