### PR TITLE
Fix broken TSDoc reference links across guide pages

### DIFF
--- a/docs/src/content/docs/guides/effects.mdx
+++ b/docs/src/content/docs/guides/effects.mdx
@@ -197,6 +197,6 @@ Here's a full example of using effects in a counter machine:
 
 Now that you understand effects, explore these related guides:
 
-- [Lifecycle Hooks](/matchina/lifecycle/) - Learn about other hooks for state changes
-- [Promise Machines](/matchina/promises/) - Handle async operations with state machines
-- [React Integration](/matchina/react/) - Use effects with React components
+- [Lifecycle Hooks](/matchina/guides/lifecycle/) - Learn about other hooks for state changes
+- [Promise Machines](/matchina/guides/promises/) - Handle async operations with state machines
+- [React Integration](/matchina/guides/react/) - Use effects with React components

--- a/docs/src/content/docs/guides/lifecycle.mdx
+++ b/docs/src/content/docs/guides/lifecycle.mdx
@@ -3,7 +3,7 @@ title: Transition Flow - Lifecycle Hooks
 description: Machine transition lifecycle
 ---
 
-Every machine in matchina runs the same transition pipeline. [FactoryMachine](/matchina/guides/machines), [StateMachine](/matchina/guides/state-machine-interface), and [StoreMachine](/matchina/reference/interfaces/storemachine/) all share one generic [EventLifecycle](/matchina/reference/interfaces/eventlifecycle), so once you know the steps for one, you know them for all three.
+Every machine in matchina runs the same transition pipeline. [FactoryMachine](/matchina/guides/machines), [StateMachine](/matchina/guides/state-machine-interface), and `StoreMachine` all share one generic `EventLifecycle`, so once you know the steps for one, you know them for all three.
 
 The table below walks a single call through `machine.send(type, ...params)` from entry to completion. If you're using a typed [api wrapper](/matchina/guides/machine-enhancers), that's where things start; otherwise, step 1 is the first frame.
 

--- a/docs/src/content/docs/guides/machines.mdx
+++ b/docs/src/content/docs/guides/machines.mdx
@@ -122,7 +122,7 @@ console.log(state.key); // Current state key
 
 ## Pattern Matching
 
-Pattern matching on state is only available if your state factory supports it (e.g. if you used a matchbox factory). For more, see the [matchbox documentation](/matchina/matchbox/).
+Pattern matching on state is only available if your state factory supports it (e.g. if you used a matchbox factory). For more, see the [matchbox documentation](/matchina/guides/matchbox-factories/).
 
 ---
 
@@ -130,7 +130,7 @@ Pattern matching on state is only available if your state factory supports it (e
 
 Now that you understand Factory Machines and matchina, explore these related guides:
 
-- [Lifecycle & Hooks](/matchina/lifecycle/) - Add hooks for intercepting state changes
-- [Effects](/matchina/effects/) - Manage side effects with the effects system
-- [Promise Machines](/matchina/promises/) - Handle async operations with state machines
-- [React Integration](/matchina/react/) - Use state machines with React
+- [Lifecycle & Hooks](/matchina/guides/lifecycle/) - Add hooks for intercepting state changes
+- [Effects](/matchina/guides/effects/) - Manage side effects with the effects system
+- [Promise Machines](/matchina/guides/promises/) - Handle async operations with state machines
+- [React Integration](/matchina/guides/react/) - Use state machines with React

--- a/docs/src/content/docs/guides/matchbox-usage.mdx
+++ b/docs/src/content/docs/guides/matchbox-usage.mdx
@@ -122,6 +122,6 @@ console.log(`Found ${largeCircles.length} large circles`);
 
 Now that you understand type guards, explore these related guides:
 
-- [Matchbox: Type-Safe Unions](/matchina/union-machines/) - Learn more about the foundation of type guards
-- [Factory Machines](/matchina/machines/) - See how type guards work with state machines
-- [Lifecycle Hooks](/matchina/lifecycle/) - Add hooks for intercepting state changes
+- [Matchbox: Type-Safe Unions](/matchina/guides/tagged-unions/) - Learn more about the foundation of type guards
+- [Factory Machines](/matchina/guides/machines/) - See how type guards work with state machines
+- [Lifecycle Hooks](/matchina/guides/lifecycle/) - Add hooks for intercepting state changes

--- a/docs/src/content/docs/guides/on-lifecycle.mdx
+++ b/docs/src/content/docs/guides/on-lifecycle.mdx
@@ -179,4 +179,4 @@ Now that you understand lifecycle hooks, explore these related guides:
 - [Factory Machines](/matchina/guides/machines) - Create complete state machines
 - [Promise Machines](/matchina/guides/promises) - Handle async operations with state machines
 - [React Integration](/matchina/guides/react) - Use lifecycle hooks with React
-- [API Reference](/matchina/reference/onLifecycle) - Full API details for `onLifecycle`
+- `onLifecycle` - Full API details for `onLifecycle`

--- a/docs/src/content/docs/guides/states.mdx
+++ b/docs/src/content/docs/guides/states.mdx
@@ -17,7 +17,7 @@ In Matchina, keyed object states are elegant strongly-typed building blocks that
 
 ### Keyed State Values
 
-[KeyedState](/matchina/reference/interfaces/keyedstate/) is the foundational state type in Matchina. It only has a `key` property, which is used to identify the state. From here, you can build more complex state types by adding more properties.
+`KeyedState` is the foundational state type in Matchina. It only has a `key` property, which is used to identify the state. From here, you can build more complex state types by adding more properties.
 
 ```ts
 export interface KeyedState {
@@ -27,7 +27,7 @@ export interface KeyedState {
 
 ### Factory States
 
-Matchina provides [`defineStates`](/matchina/reference/functions/definestates/) to create a [StateMatchboxFactory](/matchina/reference/type-aliases/statematchboxfactory/). These state factories create [StateMatchbox](matchina/reference/interfaces/statematchbox/) instances as type-safe tagged unions.
+Matchina provides `defineStates` to create a `StateMatchboxFactory`. These state factories create `StateMatchbox` instances as type-safe tagged unions.
 
 This means each state:
 - Has a unique key (tag)

--- a/docs/src/content/docs/guides/states.mdx
+++ b/docs/src/content/docs/guides/states.mdx
@@ -92,15 +92,15 @@ This means states inherit all the powerful features of Matchboxes:
 
 To fully understand and use states in Matchina, explore these related topics:
 
-- [Matchbox Factories](/matchina/matchbox-factories/) - The foundation of Matchina's type-safe state system
-- [Factory Machines](/matchina/machines/) - How states are used in complete state machines
-- [Type Safety](/matchina/matchbox-typescript-inference/) - Understanding type inference and guards
+- [Matchbox Factories](/matchina/guides/matchbox-factories/) - The foundation of Matchina's type-safe state system
+- [Factory Machines](/matchina/guides/machines/) - How states are used in complete state machines
+- [Type Safety](/matchina/guides/type-safety/) - Understanding type inference and guards
 
 ## Next Steps
 
 Now that you understand states, you might want to:
 
-1. Learn about [Factory Machines](/matchina/machines/) to use states in a complete system
-2. Explore [Lifecycle Hooks](/matchina/lifecycle/) to react to state changes
-3. Study [Effects](/matchina/effects/) to manage side effects in your state machines
-4. Try [Promise Machines](/matchina/promises/) for handling async operations
+1. Learn about [Factory Machines](/matchina/guides/machines/) to use states in a complete system
+2. Explore [Lifecycle Hooks](/matchina/guides/lifecycle/) to react to state changes
+3. Study [Effects](/matchina/guides/effects/) to manage side effects in your state machines
+4. Try [Promise Machines](/matchina/guides/promises/) for handling async operations

--- a/docs/src/content/docs/guides/transition-hooks.mdx
+++ b/docs/src/content/docs/guides/transition-hooks.mdx
@@ -83,7 +83,7 @@ setup(machine)(
 This style is ideal for highly modular or functional codebases, and can be mixed with `transitionHooks` or other enhancers.
 
 ## See Also
-- [API Reference: transitionHooks](/matchina/reference/functions/transitionhooks)
+- `transitionHooks`
 - [Stopwatch Example Using Transition Hooks](/matchina/examples/stopwatch-using-transition-hooks-instead-of-useeffect)
 
 ### Real-World Pattern


### PR DESCRIPTION
TSDoc generation was disabled, leaving guide pages with broken `/matchina/reference/...` links. This PR replaces all such hyperlinks with inline backtick code formatting.

**Files changed:**
- `docs/src/content/docs/guides/states.mdx` — 4 broken links fixed
- `docs/src/content/docs/guides/lifecycle.mdx` — 2 broken links fixed
- `docs/src/content/docs/guides/on-lifecycle.mdx` — 1 broken link fixed
- `docs/src/content/docs/guides/transition-hooks.mdx` — 1 broken link fixed